### PR TITLE
change in request format of metering service for free call

### DIFF
--- a/signer/signer.py
+++ b/signer/signer.py
@@ -23,9 +23,9 @@ class Signer:
         """
         try:
             lambda_payload = {"httpMethod": "GET",
-                              "queryStringParameters": {"organization_id": org_id,
-                                                        "service_id": service_id,
-                                                        "username": username}}
+                              "queryStringParameters": {"organization_id": org_id, "service_id": service_id},
+                              "requestContext": {"authorizer": {"claims": {"email": username}}}
+                            }
             response = self.lambda_client.invoke(FunctionName=GET_FREE_CALLS_METERING_ARN, InvocationType='RequestResponse',
                                                  Payload=json.dumps(lambda_payload))
             response_body_raw = json.loads(


### PR DESCRIPTION
Change in request format of metering service for the free call.
Instead of passing username in query params, it will be passed in the requestContext.