### PR TITLE
removing NETWORKS as global variable in respository.py

### DIFF
--- a/common/error.py
+++ b/common/error.py
@@ -1,25 +1,24 @@
-from common.constant import ERROR_MSG
 
 
 class ErrorHandler:
-    def __init__(self):
-        pass
+    def __init__(self, ERROR_MSG):
+        self.error_msg = ERROR_MSG
 
     def log_err_msg(self, err, fn_nme='', err_cd=None):
         try:
             if err_cd == None:
                 err_msg = 'Error in {}::error: {}'.format(fn_nme, repr(err))
             else:
-                err_msg = ERROR_MSG[err_cd].format(err_cd)
+                err_msg = self.error_msg[err_cd].format(err_cd)
             print(repr(err_msg))
             return err_msg
         except KeyError as e:
-            return ERROR_MSG[err_cd].format(err_cd=9001)
+            return self.error_msg[err_cd].format(err_cd=9001)
         except Exception as e:
-            return ERROR_MSG['default']
+            return self.error_msg['default']
 
     def get_err_msg(self, err_cd):
         try:
-            return ERROR_MSG[err_cd].format(err_cd)
+            return self.error_msg[err_cd].format(err_cd)
         except Exception as e:
-            return ERROR_MSG[err_cd].format(err_cd=9001)
+            return self.error_msg[err_cd].format(err_cd=9001)

--- a/common/repository.py
+++ b/common/repository.py
@@ -1,11 +1,10 @@
 import pymysql
-from common.constant import NETWORKS
 
 
 class Repository:
     connection = None
 
-    def __init__(self, net_id):
+    def __init__(self, net_id, NETWORKS):
         self.DB_HOST = NETWORKS[net_id]['db']['DB_HOST']
         self.DB_USER = NETWORKS[net_id]['db']['DB_USER']
         self.DB_PASSWORD = NETWORKS[net_id]['db']['DB_PASSWORD']

--- a/contract_api/lambda_handler.py
+++ b/contract_api/lambda_handler.py
@@ -9,7 +9,7 @@ from contract_api.mpe import MPE
 
 NETWORKS_NAME = dict((NETWORKS[netId]['name'], netId)
                      for netId in NETWORKS.keys())
-db = dict((netId, Repository(net_id=netId)) for netId in NETWORKS.keys())
+db = dict((netId, Repository(net_id=netId, NETWORKS)) for netId in NETWORKS.keys())
 obj_util = Utils()
 
 

--- a/dapp_user/lambda_handler.py
+++ b/dapp_user/lambda_handler.py
@@ -10,7 +10,7 @@ from dapp_user.user import User
 
 NETWORKS_NAME = dict((NETWORKS[netId]['name'], netId)
                      for netId in NETWORKS.keys())
-db = dict((netId, Repository(net_id=netId)) for netId in NETWORKS.keys())
+db = dict((netId, Repository(net_id=netId, NETWORKS)) for netId in NETWORKS.keys())
 obj_util = Utils()
 
 

--- a/parse_events/constant.py
+++ b/parse_events/constant.py
@@ -7,3 +7,9 @@ MPE_CNTRCT_PATH = COMMON_CNTRCT_PATH + '/abi/MultiPartyEscrow.json'
 REG_ADDR_PATH = COMMON_CNTRCT_PATH + '/networks/Registry.json'
 MPE_ADDR_PATH = COMMON_CNTRCT_PATH + '/networks/MultiPartyEscrow.json'
 EVNTS_LIMIT = "100"
+ERROR_MSG = {
+    1001: "Error Code: {} Network Id is Invalid !!",
+    1002: "Error Code: {} Unable to process _init_w3.",
+    9001: "Missing error code {} ",
+    "default": "Unable to process error."
+}

--- a/parse_events/handle_contracts.py
+++ b/parse_events/handle_contracts.py
@@ -8,7 +8,7 @@ import sys
 import web3.utils.events
 from web3 import Web3
 from parse_events.config import IPFS_URL, NETWORKS
-from parse_events.constant import MPE_EVTS, REG_EVTS, REG_CNTRCT_PATH, MPE_CNTRCT_PATH, REG_ADDR_PATH, MPE_ADDR_PATH
+from parse_events.constant import MPE_EVTS, REG_EVTS, REG_CNTRCT_PATH, MPE_CNTRCT_PATH, REG_ADDR_PATH, MPE_ADDR_PATH, ERROR_MSG
 from common.error import ErrorHandler
 from parse_events.handle_contracts_db import HandleContractsDB
 from common.utils import Utils
@@ -21,7 +21,7 @@ class HandleContracts:
         self.mpe_cntrct_addr = None
         self.reg_cntrct = None
         self.reg_cntrct_addr = None
-        self.err_obj = ErrorHandler()
+        self.err_obj = ErrorHandler(ERROR_MSG)
         self.db_obj = HandleContractsDB(err_obj=self.err_obj, net_id=net_id)
         self.util_obj = Utils()
 

--- a/parse_events/handle_contracts_db.py
+++ b/parse_events/handle_contracts_db.py
@@ -6,7 +6,7 @@ from datetime import datetime as dt
 import log_setup
 
 from parse_events.constant import EVNTS_LIMIT
-from parse_events.config import IPFS_URL, ASSETS_BUCKET_NAME, S3_BUCKET_ACCESS_KEY, S3_BUCKET_SECRET_KEY, ASSETS_PREFIX
+from parse_events.config import NETWORKS, IPFS_URL, ASSETS_BUCKET_NAME, S3_BUCKET_ACCESS_KEY, S3_BUCKET_SECRET_KEY, ASSETS_PREFIX
 from common.ipfs_util import IPFSUtil
 from common.repository import Repository
 from common.s3_util import S3Util
@@ -21,7 +21,7 @@ log_setup.configure_log(logger)
 class HandleContractsDB:
     def __init__(self, err_obj, net_id):
         self.err_obj = err_obj
-        self.repo = Repository(net_id)
+        self.repo = Repository(net_id, NETWORKS)
         self.util_obj = Utils()
         self.ipfs_utll = IPFSUtil(IPFS_URL['url'], IPFS_URL['port'])
         self.s3_util = S3Util(S3_BUCKET_ACCESS_KEY, S3_BUCKET_SECRET_KEY)

--- a/service_status/lambda_handler.py
+++ b/service_status/lambda_handler.py
@@ -10,7 +10,7 @@ from service_status.service_status import ServiceStatus
 NETWORKS_NAME = dict((NETWORKS[netId]['name'], netId)
                      for netId in NETWORKS.keys())
 obj_util = Utils()
-db = dict((netId, Repository(net_id=netId)) for netId in NETWORKS.keys())
+db = dict((netId, Repository(net_id=netId, NETWORKS)) for netId in NETWORKS.keys())
 
 
 def request_handler(event, context):

--- a/signer/lambda_handler.py
+++ b/signer/lambda_handler.py
@@ -8,7 +8,7 @@ from signer.signer import Signer
 
 NETWORKS_NAME = dict((NETWORKS[netId]['name'], netId)
                      for netId in NETWORKS.keys())
-db = dict((netId, Repository(net_id=netId)) for netId in NETWORKS.keys())
+db = dict((netId, Repository(net_id=netId, NETWORKS)) for netId in NETWORKS.keys())
 obj_util = Utils()
 
 


### PR DESCRIPTION
removing NETWORKS as a global variable in respository.py and will be passed while object initialization.