### PR TITLE
fix: edit organization details when onboarding is rejected

### DIFF
--- a/registry/domain/models/organization.py
+++ b/registry/domain/models/organization.py
@@ -272,7 +272,7 @@ class Organization:
 
     @staticmethod
     def next_state_for_update(current_organization, updated_organization):
-        if current_organization.get_statue() in [OrganizationStatus.ONBOARDING_REJECTED.value,
+        if current_organization.get_status() in [OrganizationStatus.ONBOARDING_REJECTED.value,
                                                  OrganizationStatus.REJECTED.value]:
             raise Exception("Action Not Allowed")
 

--- a/registry/domain/models/organization.py
+++ b/registry/domain/models/organization.py
@@ -272,22 +272,21 @@ class Organization:
 
     @staticmethod
     def next_state_for_update(current_organization, updated_organization):
+        if current_organization.get_statue() in [OrganizationStatus.ONBOARDING_REJECTED.value,
+                                                 OrganizationStatus.REJECTED.value]:
+            raise Exception("Action Not Allowed")
+
         if not current_organization.is_major_change(updated_organization):
-            if current_organization.get_status() == OrganizationStatus.ONBOARDING_APPROVED.value:
-                next_state = OrganizationStatus.ONBOARDING_APPROVED.value
-            elif current_organization.get_status() in [OrganizationStatus.ONBOARDING_REJECTED.value,
-                                                       OrganizationStatus.CHANGE_REQUESTED.value]:
+            if current_organization.get_status() == OrganizationStatus.CHANGE_REQUESTED.value:
                 next_state = OrganizationStatus.ONBOARDING.value
-            else:
+            elif current_organization.get_status() in \
+                    [OrganizationStatus.ONBOARDING_APPROVED.value,
+                     OrganizationStatus.APPROVED.value, OrganizationStatus.PUBLISHED.value]:
                 next_state = OrganizationStatus.APPROVED.value
-        else:
-            if current_organization.get_status() == OrganizationStatus.ONBOARDING_APPROVED.value:
-                next_state = OrganizationStatus.ONBOARDING_APPROVED.value
-            elif current_organization.get_status() in [OrganizationStatus.ONBOARDING_REJECTED.value,
-                                                       OrganizationStatus.CHANGE_REQUESTED.value]:
-                next_state = OrganizationStatus.ONBOARDING.value
             else:
                 raise MethodNotImplemented()
+        else:
+            raise MethodNotImplemented()
         return next_state
 
     def _get_all_contact_for_organization(self):

--- a/registry/domain/models/organization.py
+++ b/registry/domain/models/organization.py
@@ -275,6 +275,9 @@ class Organization:
         if not current_organization.is_major_change(updated_organization):
             if current_organization.get_status() == OrganizationStatus.ONBOARDING_APPROVED.value:
                 next_state = OrganizationStatus.ONBOARDING_APPROVED.value
+            elif current_organization.get_status() in [OrganizationStatus.ONBOARDING_REJECTED.value,
+                                                       OrganizationStatus.CHANGE_REQUESTED.value]:
+                next_state = OrganizationStatus.ONBOARDING.value
             else:
                 next_state = OrganizationStatus.APPROVED.value
         else:

--- a/registry/testcases/unit_testcases/test_organization_publisher_service.py
+++ b/registry/testcases/unit_testcases/test_organization_publisher_service.py
@@ -69,7 +69,7 @@ class TestOrganizationPublisherService(unittest.TestCase):
 
     @patch("common.ipfs_util.IPFSUtil", return_value=Mock(write_file_in_ipfs=Mock(return_value="Q3E12")))
     @patch("common.boto_utils.BotoUtils", return_value=Mock(s3_upload_file=Mock()))
-    def test_submit_organization_for_approval(self, mock_boto, mock_ipfs):
+    def test_submit_organization_for_approval_after_published(self, mock_boto, mock_ipfs):
         username = "karl@dummy.com"
         test_org_uuid = uuid4().hex
         test_org_id = "org_id"
@@ -84,20 +84,82 @@ class TestOrganizationPublisherService(unittest.TestCase):
             "state": {}
         }
         organization = OrganizationFactory.org_domain_entity_from_payload(payload)
-        org_repo.add_organization(organization, username, OrganizationStatus.DRAFT.value)
+        org_repo.add_organization(organization, username, OrganizationStatus.PUBLISHED.value)
         OrganizationPublisherService(test_org_uuid, username) \
             .update_organization(payload, OrganizationActions.SUBMIT.value)
         org_db_model = org_repo.session.query(Organization).first()
         if org_db_model is None:
             assert False
         else:
-            if org_db_model.org_state[0].state == OrganizationStatus.APPROVAL_PENDING.value:
+            if org_db_model.org_state[0].state == OrganizationStatus.APPROVED.value:
                 assert True
+            else:
+                assert False
+
+
+    @patch("common.ipfs_util.IPFSUtil", return_value=Mock(write_file_in_ipfs=Mock(return_value="Q3E12")))
+    @patch("common.boto_utils.BotoUtils", return_value=Mock(s3_upload_file=Mock()))
+    def test_submit_organization_for_approval_after_approved(self, mock_boto, mock_ipfs):
+        username = "karl@dummy.com"
+        test_org_uuid = uuid4().hex
+        test_org_id = "org_id"
+        username = "karl@cryptonian.io"
+        payload = {
+            "org_id": test_org_id, "org_uuid": test_org_uuid, "org_name": "test_org", "org_type": "organization",
+            "metadata_ipfs_uri": "", "duns_no": "123456789", "origin": ORIGIN,
+            "description": "this is description", "short_description": "this is short description",
+            "url": "https://dummy.dummy", "contacts": "",
+            "assets": {"hero_image": {"url": "", "ipfs_uri": ""}},
+            "org_address": ORG_ADDRESS, "groups": json.loads(ORG_GROUPS),
+            "state": {}
+        }
+        organization = OrganizationFactory.org_domain_entity_from_payload(payload)
+        org_repo.add_organization(organization, username, OrganizationStatus.APPROVED.value)
+        OrganizationPublisherService(test_org_uuid, username) \
+            .update_organization(payload, OrganizationActions.SUBMIT.value)
+        org_db_model = org_repo.session.query(Organization).first()
+        if org_db_model is None:
+            assert False
+        else:
+            if org_db_model.org_state[0].state == OrganizationStatus.APPROVED.value:
+                assert True
+            else:
+                assert False
+
+    @patch("common.ipfs_util.IPFSUtil", return_value=Mock(write_file_in_ipfs=Mock(return_value="Q3E12")))
+    @patch("common.boto_utils.BotoUtils", return_value=Mock(s3_upload_file=Mock()))
+    def test_submit_organization_for_approval_after_onboarding_approved(self, mock_boto, mock_ipfs):
+        username = "karl@dummy.com"
+        test_org_uuid = uuid4().hex
+        test_org_id = "org_id"
+        username = "karl@cryptonian.io"
+        payload = {
+            "org_id": test_org_id, "org_uuid": test_org_uuid, "org_name": "test_org", "org_type": "organization",
+            "metadata_ipfs_uri": "", "duns_no": "123456789", "origin": ORIGIN,
+            "description": "this is description", "short_description": "this is short description",
+            "url": "https://dummy.dummy", "contacts": "",
+            "assets": {"hero_image": {"url": "", "ipfs_uri": ""}},
+            "org_address": ORG_ADDRESS, "groups": json.loads(ORG_GROUPS),
+            "state": {}
+        }
+        organization = OrganizationFactory.org_domain_entity_from_payload(payload)
+        org_repo.add_organization(organization, username, OrganizationStatus.ONBOARDING_APPROVED.value)
+        OrganizationPublisherService(test_org_uuid, username) \
+            .update_organization(payload, OrganizationActions.SUBMIT.value)
+        org_db_model = org_repo.session.query(Organization).first()
+        if org_db_model is None:
+            assert False
+        else:
+            if org_db_model.org_state[0].state == OrganizationStatus.APPROVED.value:
+                assert True
+            else:
+                assert False
 
     @patch("common.ipfs_util.IPFSUtil", return_value=Mock(write_file_in_ipfs=Mock(return_value="Q12PWP")))
     @patch("registry.domain.services.registry_blockchain_util."
            "RegistryBlockChainUtil.publish_organization_to_test_network", return_value="0x123")
-    def test_org_publish_to_ipfs(self, mock_test_network_publish, mock_ipfs_utils):
+    @patch("registry.domain.models.organization.json_to_file")
+    def test_org_publish_to_ipfs(self, mock_json_to_file_util, mock_test_network_publish, mock_ipfs_utils):
         test_org_id = uuid4().hex
         username = "dummy@snet.io"
         org_repo.add_organization(


### PR DESCRIPTION
- if rejected then wont allow user to edit organization details
- if organization is `APPROVED` or `ONBOARDING_APPROVED` or `PUBLISHED` then organization will be auto approved
- if `CHANGE_REQUESTED` then next edit will make Organization `ONBOARDING`
- considering user will only make minor changes we wont doing any validation on that