### PR TITLE
fix: send mail for org approval after changes are submitted

### DIFF
--- a/registry/testcases/unit_testcases/test_organization_publisher_service.py
+++ b/registry/testcases/unit_testcases/test_organization_publisher_service.py
@@ -40,6 +40,37 @@ class TestOrganizationPublisherService(unittest.TestCase):
 
     @patch("common.ipfs_util.IPFSUtil", return_value=Mock(write_file_in_ipfs=Mock(return_value="Q3E12")))
     @patch("common.boto_utils.BotoUtils", return_value=Mock(s3_upload_file=Mock()))
+    @patch("common.utils.send_slack_notification")
+    def test_edit_organization_after_change_requested(self, mock_slack_notification, mock_boto, mock_ipfs):
+        username = "karl@dummy.com"
+        test_org_uuid = uuid4().hex
+        test_org_id = "org_id"
+        groups = OrganizationFactory.group_domain_entity_from_group_list_payload(json.loads(ORG_GROUPS))
+        org_repo.add_organization(
+            DomainOrganization(test_org_uuid, test_org_id, "org_dummy", "ORGANIZATION", ORIGIN, "", "",
+                               "", [], {}, "", "", groups, [], [], []),
+            username, OrganizationStatus.CHANGE_REQUESTED.value)
+        payload = json.loads(ORG_PAYLOAD_MODEL)
+        payload["org_uuid"] = test_org_uuid
+        payload["org_id"] = test_org_id
+        OrganizationPublisherService(test_org_uuid, username) \
+            .update_organization(payload, OrganizationActions.DRAFT.value)
+        org_db_model = org_repo.session.query(Organization).first()
+        if org_db_model is None:
+            assert False
+        organization = OrganizationFactory.org_domain_entity_from_repo_model(org_db_model)
+        org_dict = organization.to_response()
+        org_dict["state"] = {}
+        org_dict["groups"] = []
+        org_dict["assets"]["hero_image"]["url"] = ""
+        expected_organization = json.loads(ORG_RESPONSE_MODEL)
+        expected_organization["org_id"] = test_org_id
+        expected_organization["groups"] = []
+        expected_organization["org_uuid"] = test_org_uuid
+        self.assertDictEqual(expected_organization, org_dict)
+
+    @patch("common.ipfs_util.IPFSUtil", return_value=Mock(write_file_in_ipfs=Mock(return_value="Q3E12")))
+    @patch("common.boto_utils.BotoUtils", return_value=Mock(s3_upload_file=Mock()))
     def test_edit_organization(self, mock_boto, mock_ipfs):
         username = "karl@dummy.com"
         test_org_uuid = uuid4().hex


### PR DESCRIPTION
- after `CHANGE_REQUESTED`, when user submits the organization, send mail to approvers.