### PR TITLE
fixes publish service in Test Network

### DIFF
--- a/registry/domain/services/registry_blockchain_util.py
+++ b/registry/domain/services/registry_blockchain_util.py
@@ -55,7 +55,7 @@ class RegistryBlockChainUtil:
         transaction_object = self.__blockchain_util.create_transaction_object(
             *positional_inputs, method_name=method_name, address=self.__executor_address,
             contract_path=self.__contract_path, contract_address_path=self.__contract_address_path,
-            net_id=self.__network_id)
+            net_id=BLOCKCHAIN_TEST_ENV["network_id"])
         return transaction_object
 
     def __make_trasaction(self, *positional_inputs, method_name):


### PR DESCRIPTION
blockchain test environment network id needs to be used for creating a transaction object in the TEST environment