### PR TITLE
Registry | Fixes update transaction status issue.

### DIFF
--- a/registry/application/services/service_transaction_status.py
+++ b/registry/application/services/service_transaction_status.py
@@ -23,9 +23,9 @@ class ServiceTransactionStatus:
                 transaction_hash=transaction_hash)
             if transaction_receipt is None:
                 pass
-            else:
-                if transaction_receipt.status == 0:
-                    failed_service_transactions.append(service_uuid)
-                    logger.info(f"Failed service_uuid:{service_uuid} transaction_hash:{transaction_hash}")
+            elif transaction_receipt.status == 0:
+                failed_service_transactions.append(service_uuid)
+                logger.info(f"Failed service_uuid:{service_uuid} transaction_hash:{transaction_hash}")
         if len(failed_service_transactions) > 0:
-            service_repo.update_service_status(failed_service_transactions, ServiceStatus.PUBLISH_IN_PROGRESS.value, ServiceStatus.FAILED.value)
+            service_repo.update_service_status(failed_service_transactions, ServiceStatus.PUBLISH_IN_PROGRESS.value,
+                                               ServiceStatus.FAILED.value)

--- a/registry/application/services/service_transaction_status.py
+++ b/registry/application/services/service_transaction_status.py
@@ -14,8 +14,7 @@ class ServiceTransactionStatus:
                                                                   provider=NETWORKS[NETWORK_ID]['http_provider'])
 
     def update_transaction_status(self):
-        org_transaction_data = service_repo.get_service_state_with_status(
-            ServiceStatus.PUBLISH_IN_PROGRESS.value)
+        org_transaction_data = service_repo.get_service_state_with_status(ServiceStatus.PUBLISH_IN_PROGRESS.value)
         failed_service_transactions = []
         for service_state in org_transaction_data:
             service_uuid = service_state.service_uuid
@@ -23,13 +22,10 @@ class ServiceTransactionStatus:
             transaction_receipt = self.obj_blockchain_util.get_transaction_receipt_from_blockchain(
                 transaction_hash=transaction_hash)
             if transaction_receipt is None:
-                logger.error(f"Failed to get the transaction from blockchain for "
-                             f"serivce:{service_uuid} hash:{transaction_hash}")
+                pass
             else:
                 if transaction_receipt.status == 0:
                     failed_service_transactions.append(service_uuid)
                     logger.info(f"Failed service_uuid:{service_uuid} transaction_hash:{transaction_hash}")
-        if len(failed_service_transactions) == 0:
-            return
-        service_repo.update_service_status(failed_service_transactions, ServiceStatus.PUBLISH_IN_PROGRESS.value,
-                                           ServiceStatus.FAILED.value)
+        if len(failed_service_transactions) > 0:
+            service_repo.update_service_status(failed_service_transactions, ServiceStatus.PUBLISH_IN_PROGRESS.value, ServiceStatus.FAILED.value)


### PR DESCRIPTION
If blockchain transaction is in pending state, w3.eth.getTransactionReceipt(transaction_hash) will return None. We don't have to raise the TransactionNotFound exception.