### PR TITLE
Offset and limit are now in line on what was done for market place dapp

### DIFF
--- a/registry/application/services/service_publisher_service.py
+++ b/registry/application/services/service_publisher_service.py
@@ -28,7 +28,7 @@ from registry.infrastructure.repositories.organization_repository import Organiz
 from registry.infrastructure.repositories.service_publisher_repository import ServicePublisherRepository
 from deepdiff import DeepDiff
 
-#patch_all()
+patch_all()
 ALLOWED_ATTRIBUTES_FOR_SERVICE_SEARCH = ["display_name"]
 DEFAULT_ATTRIBUTE_FOR_SERVICE_SEARCH = "display_name"
 ALLOWED_ATTRIBUTES_FOR_SERVICE_SORT_BY = ["ranking", "service_id"]

--- a/registry/application/services/service_publisher_service.py
+++ b/registry/application/services/service_publisher_service.py
@@ -191,37 +191,18 @@ class ServicePublisherService:
         search_attribute = payload["s"]
         sort_by = payload["sort_by"].lower()
         order_by = payload["order_by"].lower()
-        filter_parameters_total_count = {  "search_string": search_string,
-                                           "search_attribute": search_attribute if search_attribute in
-                                                                                   ALLOWED_ATTRIBUTES_FOR_SERVICE_SEARCH
-                                           else DEFAULT_ATTRIBUTE_FOR_SERVICE_SEARCH}
-        search_count = ServicePublisherRepository().\
-            get_total_count_of_services_for_organization(self._org_uuid,filter_parameters_total_count)
-        # a = ("a", "b", "c", "d", "e", "f", "g", "h")
-        # x = slice(3, 5)  , so 3 is the offset , which means starting a[3] and 2 elements after (2 is the limit)
-        # which is a[5]
-        # front end will send the offset as 3 and limit as 2 , hence we need adjust
-        # print(a[x]) , ('d', 'e')
-        revised_offset = offset
-        if revised_offset > search_count:
-            revised_offset = search_count
-        revised_limit = offset + limit
-        if revised_limit > search_count :
-            revised_limit = search_count
-
         filter_parameters = {
-            "offset": revised_offset,
-            "limit": revised_limit,
+            "offset": offset,
+            "limit": limit,
             "search_string": search_string,
             "search_attribute": search_attribute if search_attribute in ALLOWED_ATTRIBUTES_FOR_SERVICE_SEARCH else DEFAULT_ATTRIBUTE_FOR_SERVICE_SEARCH,
             "sort_by": sort_by if sort_by in ALLOWED_ATTRIBUTES_FOR_SERVICE_SORT_BY else DEFAULT_ATTRIBUTES_FOR_SERVICE_SORT_BY,
             "order_by": order_by if order_by in ALLOWED_ATTRIBUTES_FOR_SERVICE_SORT_BY else DEFAULT_ATTRIBUTES_FOR_SERVICE_ORDER_BY
         }
-
-
         services = ServicePublisherRepository().get_services_for_organization(self._org_uuid, filter_parameters)
         search_result = [service.to_dict() for service in services]
-
+        search_count = ServicePublisherRepository().get_total_count_of_services_for_organization(self._org_uuid,
+                                                                                                 filter_parameters)
         return {"total_count": search_count, "offset": offset, "limit": limit, "result": search_result}
 
     def get_service_comments(self):

--- a/registry/infrastructure/repositories/service_publisher_repository.py
+++ b/registry/infrastructure/repositories/service_publisher_repository.py
@@ -21,7 +21,8 @@ class ServicePublisherRepository(BaseRepository):
                 filter(getattr(Service, payload["search_attribute"]).like("%" + payload["search_string"] + "%")). \
                 filter(Service.org_uuid == org_uuid). \
                 order_by(getattr(getattr(Service, payload["sort_by"]), payload["order_by"])()). \
-                slice(payload["offset"], payload["limit"]).all()
+                offset(payload["offset"]).limit(payload["limit"]).all()
+
             self.session.commit()
         except Exception as e:
             self.session.rollback()

--- a/registry/testcases/functional_testcases/test_service.py
+++ b/registry/testcases/functional_testcases/test_service.py
@@ -383,7 +383,7 @@ class TestService(TestCase):
             "pathParameters": {"org_uuid": "test_org_uuid"},
             "body": json.dumps({
                 "q": "display",
-                "limit": 10,
+                "limit": 1,
                 "offset": 1,
                 "s": "all",
                 "sort_by": "display_name",
@@ -397,9 +397,64 @@ class TestService(TestCase):
         assert (response_body["status"] == "success")
         assert (response_body["data"]["total_count"] == 3)
         assert (response_body["data"]["offset"] == 1)
-        assert (response_body["data"]["limit"] == 10)
-        assert (len(response_body["data"]["result"]) == 2)
-
+        assert (response_body["data"]["limit"] == 1)
+        assert (len(response_body["data"]["result"]) == 1)
+        event = {
+            "requestContext": {
+                "authorizer": {
+                    "claims": {
+                        "email": "dummy_user1@dummy.io"
+                    }
+                }
+            },
+            "httpMethod": "GET",
+            "pathParameters": {"org_uuid": "test_org_uuid"},
+            "body": json.dumps({
+                "q": "display",
+                "limit": 2,
+                "offset": 2,
+                "s": "all",
+                "sort_by": "display_name",
+                "order_by": "desc",
+                "filters": []
+            })
+        }
+        response = get_services_for_organization(event=event, context=None)
+        assert (response["statusCode"] == 200)
+        response_body = json.loads(response["body"])
+        assert (response_body["status"] == "success")
+        assert (response_body["data"]["total_count"] == 3)
+        assert (response_body["data"]["offset"] == 2)
+        assert (response_body["data"]["limit"] == 2)
+        assert (len(response_body["data"]["result"]) == 1)
+        event = {
+            "requestContext": {
+                "authorizer": {
+                    "claims": {
+                        "email": "dummy_user1@dummy.io"
+                    }
+                }
+            },
+            "httpMethod": "GET",
+            "pathParameters": {"org_uuid": "test_org_uuid"},
+            "body": json.dumps({
+                "q": "display",
+                "limit": 12,
+                "offset": 0,
+                "s": "all",
+                "sort_by": "display_name",
+                "order_by": "desc",
+                "filters": []
+            })
+        }
+        response = get_services_for_organization(event=event, context=None)
+        assert (response["statusCode"] == 200)
+        response_body = json.loads(response["body"])
+        assert (response_body["status"] == "success")
+        assert (response_body["data"]["total_count"] == 3)
+        assert (response_body["data"]["offset"] == 0)
+        assert (response_body["data"]["limit"] == 12)
+        assert (len(response_body["data"]["result"]) == 3)
     def test_save_service(self):
         org_repo.add_item(
             OrganizationDBModel(

--- a/registry/testcases/functional_testcases/test_service.py
+++ b/registry/testcases/functional_testcases/test_service.py
@@ -272,8 +272,8 @@ class TestService(TestCase):
                 service_uuid="test_service_uuid",
                 state="DRAFT",
                 transaction_hash=None,
-                created_by="dummy_user",
-                updated_by="dummy_user",
+                created_by="dummy_user1@dummy.io",
+                updated_by="dummy_user1@dummy.io",
                 created_on=dt.utcnow()
             )
         )
@@ -282,6 +282,86 @@ class TestService(TestCase):
                 row_id="1000",
                 org_uuid="test_org_uuid",
                 service_uuid="test_service_uuid",
+                group_id="test_group_id",
+                pricing={},
+                endpoints={"https://dummydaemonendpoint.io": {"verfied": True}},
+                daemon_address=["0xq2w3e4rr5t6y7u8i9"],
+                free_calls=10,
+                free_call_signer_address="",
+                created_on=dt.utcnow()
+            )
+        )
+        service_repo.add_item(
+            ServiceDBModel(
+                org_uuid="test_org_uuid",
+                uuid="test_service_uuid1",
+                display_name="test_display_name",
+                service_id="test_service_id",
+                metadata_uri="Qasdfghjklqwertyuiopzxcvbnm",
+                short_description="test_short_description",
+                description="test_description",
+                project_url="https://dummy.io",
+                ranking=1,
+                created_on=dt.utcnow()
+            )
+        )
+        service_repo.add_item(
+            ServiceStateDBModel(
+                row_id=1001,
+                org_uuid="test_org_uuid",
+                service_uuid="test_service_uuid1",
+                state="DRAFT",
+                transaction_hash=None,
+                created_by="dummy_user1@dummy.io",
+                updated_by="dummy_user1@dummy.io",
+                created_on=dt.utcnow()
+            )
+        )
+        service_repo.add_item(
+            ServiceGroupDBModel(
+                row_id="1001",
+                org_uuid="test_org_uuid",
+                service_uuid="test_service_uuid1",
+                group_id="test_group_id",
+                pricing={},
+                endpoints={"https://dummydaemonendpoint.io": {"verfied": True}},
+                daemon_address=["0xq2w3e4rr5t6y7u8i9"],
+                free_calls=10,
+                free_call_signer_address="",
+                created_on=dt.utcnow()
+            )
+        )
+        service_repo.add_item(
+            ServiceDBModel(
+                org_uuid="test_org_uuid",
+                uuid="test_service_uuid2",
+                display_name="test_display_name",
+                service_id="test_service_id",
+                metadata_uri="Qasdfghjklqwertyuiopzxcvbnm",
+                short_description="test_short_description",
+                description="test_description",
+                project_url="https://dummy.io",
+                ranking=1,
+                created_on=dt.utcnow()
+            )
+        )
+        service_repo.add_item(
+            ServiceStateDBModel(
+                row_id=1002,
+                org_uuid="test_org_uuid",
+                service_uuid="test_service_uuid2",
+                state="DRAFT",
+                transaction_hash=None,
+                created_by="dummy_user1@dummy.io",
+                updated_by="dummy_user1@dummy.io",
+                created_on=dt.utcnow()
+            )
+        )
+        service_repo.add_item(
+            ServiceGroupDBModel(
+                row_id="1002",
+                org_uuid="test_org_uuid",
+                service_uuid="test_service_uuid2",
                 group_id="test_group_id",
                 pricing={},
                 endpoints={"https://dummydaemonendpoint.io": {"verfied": True}},
@@ -304,7 +384,7 @@ class TestService(TestCase):
             "body": json.dumps({
                 "q": "display",
                 "limit": 10,
-                "offset": 0,
+                "offset": 1,
                 "s": "all",
                 "sort_by": "display_name",
                 "order_by": "desc",
@@ -315,10 +395,10 @@ class TestService(TestCase):
         assert (response["statusCode"] == 200)
         response_body = json.loads(response["body"])
         assert (response_body["status"] == "success")
-        assert (response_body["data"]["total_count"] == 1)
-        assert (response_body["data"]["offset"] == 0)
+        assert (response_body["data"]["total_count"] == 3)
+        assert (response_body["data"]["offset"] == 1)
         assert (response_body["data"]["limit"] == 10)
-        assert (len(response_body["data"]["result"]) == 1)
+        assert (len(response_body["data"]["result"]) == 2)
 
     def test_save_service(self):
         org_repo.add_item(


### PR DESCRIPTION
We were  using slice 
a = ("a", "b", "c", "d", "e", "f", "g", "h")
x = slice(3, 5)
print(a[x])

offset and limit are now set in the Query itself 

```
      services_db = self.session.query(Service). \
                filter(getattr(Service, payload["search_attribute"]).like("%" + payload["search_string"] + "%")). \
                filter(Service.org_uuid == org_uuid). \
                order_by(getattr(getattr(Service, payload["sort_by"]), payload["order_by"])()). \
                slice(payload["offset"], payload["limit"]).all()
```